### PR TITLE
improve error messages in Apply to instace proccess

### DIFF
--- a/forward_engineering/helpers/applyToInstanceHelper.js
+++ b/forward_engineering/helpers/applyToInstanceHelper.js
@@ -16,7 +16,15 @@ const applyToInstance = async (connectionInfo, logger, app) => {
 		logger.progress({ message });
 		logger.log('info', { message }, 'Apply to instance');
 
-		await snowflakeHelper.applyScript(query);
+		try {
+			await snowflakeHelper.applyScript(query);
+		} catch (error) {
+			logger.log('error', error, `Failed to apply statement:\n${query}`);
+			throw {
+				...error,
+				message: `Failed to apply statement:\n${query.substring(0, 80)}...\nReason: ${error.message}`
+			}
+		}
 	});
 };
 


### PR DESCRIPTION
### Content:

Added first part of failed statement from the Apply to instance process to the error message to make error message more descriptive.