### PR TITLE
skip-ci: new dev version 0.1.83

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Snowflake",
-	"version": "0.1.81",
+	"version": "0.1.83",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Snowflake",
-			"version": "0.1.81",
+			"version": "0.1.83",
 			"dependencies": {
 				"async": "3.2.5",
 				"axios": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Snowflake",
-    "version": "0.1.82",
+    "version": "0.1.83",
     "versionDate": "2024-03-29",
     "author": "hackolade",
     "engines": {


### PR DESCRIPTION
Bump manually after TC failed due to branch protection rules during the latest release.