### PR TITLE
HCK-7381: change a tag value field type to text

### DIFF
--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -173,9 +173,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -915,9 +915,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -516,9 +516,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -944,9 +946,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -1354,9 +1358,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -1764,9 +1770,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -2174,9 +2182,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -2489,9 +2499,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -2817,9 +2829,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -3137,9 +3151,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -3466,9 +3482,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -3803,9 +3821,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -4140,9 +4160,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -4477,9 +4499,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -4896,9 +4920,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -5227,9 +5253,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			},
@@ -5314,9 +5342,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			}

--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -85,9 +85,11 @@
 						"propertyName": "Value",
 						"propertyKeyword": "tagValue",
 						"propertyTooltip": "",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"regex": "^.{0,256}$"
+						}
 					}
 				]
 			}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7381" title="HCK-7381" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-7381</a>  Tag value (details) and tag allowed values (tag): should be type "text" (and not textarea) with 256 char max in that text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
