### PR TITLE
HCK-7867: move default value into configs to add it only when the dependency is satisfied

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -10,10 +10,7 @@
 	},
 	"collection": {
 		"collectionName": "New table",
-		"external": false,
-		"formatTypeOptions": {
-			"NULL_IF": [{ "NULL_IF_item": "\\N" }]
-		}
+		"external": false
 	},
 	"field": {
 		"name": "New column",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -648,6 +648,9 @@ making sure that you maintain a proper JSON format.
 						}
 					]
 				},
+				"defaultValue": {
+					"NULL_IF": [{ "NULL_IF_item": "\\N" }]
+				},
 				"structure": [
 					{
 						"propertyName": "Trim space",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7867" title="HCK-7867" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-7867</a>  Fix Snowflake default values
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Removed it from `defaultData` because it was added to all collections even those that doesn't satisfy dependency. Moved it to `formatTypeOptions` for ORC. It already existed in `formatTypeOptions` for CSV