### PR TITLE
Improved table config to show DATA_RETENTION_TIME_IN_DAYS and MAX_DATA_EXTENSION_TIME_IN_DAYS only for non-external tables

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -1259,11 +1259,41 @@ making sure that you maintain a proper JSON format.
 				"minValue": 0,
 				"maxValue": 90,
 				"dependency": {
-					"type": "not",
-					"values": {
-						"key": "external",
-						"value": true
-					}
+					"type": "or",
+					"values": [
+						{
+							"type": "and",
+							"values": [
+								{
+									"type": "not",
+									"values": {
+										"key": "external",
+										"value": true
+									}
+								},
+								{
+									"type": "not",
+									"values": {
+										"key": "iceberg",
+										"value": true
+									}
+								}
+							]
+						},
+						{
+							"type": "and",
+							"values": [
+								{
+									"key": "iceberg",
+									"value": true
+								},
+								{
+									"key": "catalogMgmt",
+									"value": "snowflake"
+								}
+							]
+						}
+					]
 				}
 			},
 			{
@@ -1279,11 +1309,23 @@ making sure that you maintain a proper JSON format.
 					"type": "or",
 					"values": [
 						{
-							"type": "not",
-							"values": {
-								"key": "external",
-								"value": true
-							}
+							"type": "and",
+							"values": [
+								{
+									"type": "not",
+									"values": {
+										"key": "external",
+										"value": true
+									}
+								},
+								{
+									"type": "not",
+									"values": {
+										"key": "iceberg",
+										"value": true
+									}
+								}
+							]
 						},
 						{
 							"type": "and",
@@ -1293,7 +1335,7 @@ making sure that you maintain a proper JSON format.
 									"value": true
 								},
 								{
-									"key": "catalog",
+									"key": "catalogMgmt",
 									"value": "snowflake"
 								}
 							]


### PR DESCRIPTION
## Content

When the table is external (flag is checked)

* `Data retention in days` and `Max data extension time in days` properties are not visible

When the table isn’t external and isn't iceberg 

* `Data retention in days` and `Max data extension time in days` properties are visible

When the bale is iceberg and Catalog management is snowflake

* `Data retention in days` and `Max data extension time in days` properties are visible

When the bale is iceberg and Catalog management is external

* `Data retention in days` and `Max data extension time in days` properties are not visible