### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -135,7 +135,7 @@ module.exports = (baseProvider, options, app) => {
 			isCaseSensitive,
 			tags,
 			schemaTags,
-			isActivated,
+			isActivated = true,
 		}) {
 			const transientStatement = preSpace(transient && 'TRANSIENT');
 			const dataRetentionStatement =

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -135,6 +135,7 @@ module.exports = (baseProvider, options, app) => {
 			isCaseSensitive,
 			tags,
 			schemaTags,
+			isActivated,
 		}) {
 			const transientStatement = preSpace(transient && 'TRANSIENT');
 			const dataRetentionStatement =
@@ -269,7 +270,7 @@ module.exports = (baseProvider, options, app) => {
 
 			statements.push(schemaStatement);
 
-			return [
+			const statement = [
 				...statements,
 				...userDefinedFunctions,
 				...proceduresStatements,
@@ -278,6 +279,7 @@ module.exports = (baseProvider, options, app) => {
 				...stagesStatements,
 				...tagsStatements,
 			].join('\n');
+			return commentIfDeactivated(statement, { isActivated });
 		},
 
 		hydrateJsonSchemaColumn(jsonSchema, definitionJsonSchema) {
@@ -660,6 +662,7 @@ module.exports = (baseProvider, options, app) => {
 				managedAccess: containerData.managedAccess,
 				dataRetention: containerData.DATA_RETENTION_TIME_IN_DAYS,
 				schemaTags: containerData.schemaTags,
+				isActivated: containerData.isActivated,
 				udfs: Array.isArray(udfs)
 					? udfs
 							.map(udf =>

--- a/forward_engineering/helpers/commentHelpers/commentDeactivatedHelper.js
+++ b/forward_engineering/helpers/commentHelpers/commentDeactivatedHelper.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const STARTS_QUERY = ['//'];
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {

--- a/forward_engineering/helpers/commentHelpers/commentDeactivatedHelper.js
+++ b/forward_engineering/helpers/commentHelpers/commentDeactivatedHelper.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const STARTS_QUERY = ['//'];
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
-	if (_.has(data, 'isActivated') && !data.isActivated) {
+	if (data.isActivated === false) {
 		if (isPartOfLine) {
 			return '// ' + statement;
 		} else if (statement.includes('\n')) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...