### PR TITLE
HCK-10000: fix duplicated column in FE of composite Primary Key, fix config for PK constraint name on field level

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -626,6 +626,9 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		hydrateColumn({ columnDefinition, jsonSchema, dbData }) {
+			const pkConstraintName = jsonSchema.compositePrimaryKey ? undefined : jsonSchema.primaryKeyConstraintName;
+			const ukConstraintName = jsonSchema.compositeUniqueKey ? undefined : jsonSchema.uniqueKeyConstraintName;
+
 			return {
 				...columnDefinition,
 				name: getName(jsonSchema.isCaseSensitive, columnDefinition.name),
@@ -658,12 +661,10 @@ module.exports = (baseProvider, options, app) => {
 					: {},
 				comment: jsonSchema.refDescription || jsonSchema.description,
 				unique: jsonSchema.uniqueKeyConstraintName ? false : jsonSchema.unique,
-				primaryKeyConstraintName: jsonSchema.primaryKeyConstraintName,
-				compositePrimaryKey:
-					jsonSchema.compositePrimaryKey || (jsonSchema.primaryKeyConstraintName && jsonSchema.primaryKey),
-				compositeUniqueKey:
-					jsonSchema.compositeUniqueKey || (jsonSchema.uniqueKeyConstraintName && jsonSchema.unique),
-				uniqueKeyConstraintName: jsonSchema.uniqueKeyConstraintName,
+				primaryKeyConstraintName: pkConstraintName,
+				compositePrimaryKey: jsonSchema.compositePrimaryKey || (pkConstraintName && jsonSchema.primaryKey),
+				compositeUniqueKey: jsonSchema.compositeUniqueKey || (ukConstraintName && jsonSchema.unique),
+				uniqueKeyConstraintName: ukConstraintName,
 				primaryKey: jsonSchema.primaryKeyConstraintName ? false : columnDefinition.primaryKey,
 				expression: jsonSchema.expression,
 				columnTags: jsonSchema.columnTags ?? [],

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -329,8 +329,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -889,8 +901,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -1436,8 +1460,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -1983,8 +2019,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -2530,8 +2578,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -3070,8 +3130,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -3537,8 +3609,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -3990,8 +4074,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -4456,8 +4552,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -4930,8 +5038,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -5404,8 +5524,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -5878,8 +6010,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -6434,8 +6578,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{
@@ -6880,8 +7036,20 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKeyConstraintName",
 				"propertyType": "text",
 				"dependency": {
-					"key": "primaryKey",
-					"value": true
+					"type": "and",
+					"values": [
+						{
+							"key": "primaryKey",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "compositePrimaryKey",
+								"value": true
+							}
+						}
+					]
 				}
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10000" title="HCK-10000" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10000</a>  Snowflake FE and PP bug
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* composite Primary Key can only be visible if the column is single primary key (meaning PK is chosen on field level)
* Fixed issue with duplicated column in PK when the column in added to the composite PK on collection level, but have a `primaryKeyConstraintName` the same as a constraint name on collection level. 
