### PR TITLE
HCK-10107: FE already escaped comments correctly

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -1,13 +1,14 @@
-'use strict';
-
 const _ = require('lodash');
 const { commentDropStatements } = require('./helpers/commentHelpers/commentDropStatements');
 const { DROP_STATEMENTS } = require('./helpers/constants');
+const { getAlterScript } = require('./helpers/alterScriptFromDeltaHelper');
+const { applyToInstance } = require('./helpers/applyToInstanceHelper');
+const { getSystemInfo } = require('../reverse_engineering/helpers/loggerHelper');
+const reApi = require('../reverse_engineering/api');
 
 module.exports = {
 	generateScript(data, logger, callback, app) {
 		try {
-			const { getAlterScript } = require('./helpers/alterScriptFromDeltaHelper');
 			const ddlProvider = require('./ddlProvider')(_, data.options, app);
 
 			const collection = JSON.parse(data.jsonSchema);
@@ -45,9 +46,6 @@ module.exports = {
 	},
 
 	applyToInstance(connectionInfo, logger, callback, app) {
-		const { applyToInstance } = require('./helpers/applyToInstanceHelper');
-		const { getSystemInfo } = require('../reverse_engineering/helpers/loggerHelper');
-
 		logger.clear();
 		logger.log('info', getSystemInfo(connectionInfo.appVersion), 'Apply to instance');
 		logger.log(
@@ -72,14 +70,10 @@ module.exports = {
 	},
 
 	async getExternalBrowserUrl(connectionInfo, logger, cb, app) {
-		const reApi = require('../reverse_engineering/api');
-
 		reApi.getExternalBrowserUrl(connectionInfo, logger, cb, app);
 	},
 
 	testConnection(connectionInfo, logger, callback, app) {
-		const reApi = require('../reverse_engineering/api');
-
 		reApi.testConnection(connectionInfo, logger, callback, app);
 	},
 

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -68,8 +68,15 @@ module.exports = (baseProvider, options, app) => {
 		getViewSelectStatement,
 	} = require('./helpers/tableHelper')(app);
 
-	const { decorateType, getDefault, getAutoIncrement, getCollation, getInlineConstraint, createExternalColumn } =
-		require('./helpers/columnDefinitionHelper')(app);
+	const {
+		decorateType,
+		getDefault,
+		getAutoIncrement,
+		getCollation,
+		getInlineConstraint,
+		createExternalColumn,
+		prepareComment,
+	} = require('./helpers/columnDefinitionHelper')(app);
 
 	const { commentIfDeactivated } = require('./helpers/commentHelpers/commentDeactivatedHelper');
 
@@ -473,9 +480,7 @@ module.exports = (baseProvider, options, app) => {
 				identity: getAutoIncrement(columnDefinition.type, 'IDENTITY', columnDefinition.identity),
 				not_nul: preSpace(!columnDefinition.nullable && 'NOT NULL'),
 				inline_constraint: getInlineConstraint(columnDefinition),
-				comment: preSpace(
-					columnDefinition.comment && `COMMENT ${escapeString(scriptFormat, columnDefinition.comment)}`,
-				),
+				comment: prepareComment({ scriptFormat, comment: columnDefinition.comment }),
 				tag: getTagStatement({
 					tags: columnDefinition.columnTags,
 					isCaseSensitive: columnDefinition.isCaseSensitive,
@@ -937,7 +942,9 @@ module.exports = (baseProvider, options, app) => {
 					AUTO_REFRESH: toBoolean(firstTab.AUTO_REFRESH),
 					PATTERN: firstTab.PATTERN ? toString(firstTab.PATTERN) : '',
 				},
-				columns: firstTab.external ? tableData.columnDefinitions.map(createExternalColumn) : tableData.columns,
+				columns: firstTab.external
+					? tableData.columnDefinitions.map(createExternalColumn(scriptFormat))
+					: tableData.columns,
 				compositePrimaryKeys: Object.entries(compositePrimaryKeys).map(([name, keys]) =>
 					generateConstraint({
 						name,

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -33,12 +33,27 @@ const {
 const { escapeString } = require('./utils/escapeString');
 const { joinActivatedAndDeactivatedStatements } = require('./utils/joinActivatedAndDeactivatedStatements');
 const { preSpace } = require('./utils/preSpace');
+const assignTemplates = require('./utils/assignTemplates');
+const {
+	toString,
+	toBoolean,
+	composeClusteringKey,
+	foreignKeysToString,
+	checkIfForeignKeyActivated,
+	foreignActiveKeysToString,
+	getName,
+	getFullName,
+	getDbName,
+	viewColumnsToString,
+} = require('./helpers/general');
+const { generateConstraint } = require('./helpers/constraintHelper');
+const getFormatTypeOptions = require('./helpers/getFormatTypeOptions');
+const { getStageCopyOptions } = require('./helpers/getStageCopyOptions');
 
 const DEFAULT_SNOWFLAKE_SEQUENCE_START = 1;
 const DEFAULT_SNOWFLAKE_SEQUENCE_INCREMENT = 1;
 
 module.exports = (baseProvider, options, app) => {
-	const assignTemplates = app.require('@hackolade/ddl-fe-utils').assignTemplates;
 	const { tab, hasType, clean } = app.require('@hackolade/ddl-fe-utils').general;
 	const scriptFormat = options?.targetScriptOptions?.keyword || FORMATS.SNOWSIGHT;
 
@@ -52,26 +67,10 @@ module.exports = (baseProvider, options, app) => {
 		getTableExtraProps,
 		getViewSelectStatement,
 	} = require('./helpers/tableHelper')(app);
-	const getFormatTypeOptions = require('./helpers/getFormatTypeOptions')(app);
-	const { getStageCopyOptions } = require('./helpers/getStageCopyOptions')(app);
-
-	const {
-		toString,
-		toBoolean,
-		composeClusteringKey,
-		foreignKeysToString,
-		checkIfForeignKeyActivated,
-		foreignActiveKeysToString,
-		getName,
-		getFullName,
-		getDbName,
-		viewColumnsToString,
-	} = require('./helpers/general')(app);
 
 	const { decorateType, getDefault, getAutoIncrement, getCollation, getInlineConstraint, createExternalColumn } =
 		require('./helpers/columnDefinitionHelper')(app);
 
-	const { generateConstraint } = require('./helpers/constraintHelper')(app);
 	const { commentIfDeactivated } = require('./helpers/commentHelpers/commentDeactivatedHelper');
 
 	const {

--- a/forward_engineering/helpers/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/helpers/alterScriptFromDeltaHelper.js
@@ -42,12 +42,12 @@ const getAlterCollectionsScripts = ({ collection, ddlProvider, app, scriptFormat
 	const addedCollectionScripts = getCollectionScripts(
 		getItems(collection, 'entities', 'added', 'values'),
 		'created',
-		getAddCollectionScript({ ddlProvider, app, scriptFormat }),
+		getAddCollectionScript({ ddlProvider, scriptFormat }),
 	);
 	const deletedCollectionScripts = getCollectionScripts(
 		getItems(collection, 'entities', 'deleted', 'values'),
 		'deleted',
-		getDeleteCollectionScript(app),
+		getDeleteCollectionScript,
 	);
 
 	const modifiedCollectionScripts = getCollectionScripts(
@@ -58,15 +58,15 @@ const getAlterCollectionsScripts = ({ collection, ddlProvider, app, scriptFormat
 
 	const addedColumnScripts = getColumnScripts(
 		getItems(collection, 'entities', 'added', 'values'),
-		getAddColumnScript({ ddlProvider, app, scriptFormat }),
+		getAddColumnScript({ ddlProvider, scriptFormat }),
 	);
 	const deletedColumnScripts = getColumnScripts(
 		getItems(collection, 'entities', 'deleted', 'values'),
-		getDeleteColumnScript(app),
+		getDeleteColumnScript,
 	);
 	const modifiedColumnScripts = getColumnScripts(
 		getItems(collection, 'entities', 'modified', 'values'),
-		getModifyColumnScript(app),
+		getModifyColumnScript,
 	);
 
 	return {
@@ -100,7 +100,7 @@ const getAlterViewsScripts = ({ schema, ddlProvider, app }) => {
 	const deletedViewScripts = getViewScripts(
 		getItems(schema, 'views', 'deleted', 'values'),
 		'deleted',
-		getDeleteViewScript(app),
+		getDeleteViewScript,
 	);
 	const modifiedViewScripts = getModifiedScript(
 		getItems(schema, 'views', 'modified', 'values'),
@@ -119,13 +119,13 @@ const getAlterViewsScripts = ({ schema, ddlProvider, app }) => {
  */
 const getAlterTagsScripts = ({ collection, ddlProvider, app }) => {
 	const addedTagsScripts = getItems(collection, 'containers', 'added', 'values').flatMap(
-		getAddTagScript({ ddlProvider, app }),
+		getAddTagScript({ ddlProvider }),
 	);
 	const deletedTagsScripts = getItems(collection, 'containers', 'deleted', 'values').flatMap(
-		getDeleteTagScript({ ddlProvider, app }),
+		getDeleteTagScript({ ddlProvider }),
 	);
 	const modifiedTagsScripts = getItems(collection, 'containers', 'modified', 'values').flatMap(
-		getModifyTagScript({ ddlProvider, app }),
+		getModifyTagScript({ ddlProvider }),
 	);
 	return { addedTagsScripts, deletedTagsScripts, modifiedTagsScripts };
 };

--- a/forward_engineering/helpers/alterScriptHelpers/alterContainerHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterContainerHelper.js
@@ -1,7 +1,7 @@
 const { prepareContainerLevelData } = require('./common');
+const { getDbName } = require('../general');
 
-const getAddContainerScript = (ddlProvider, app) => container => {
-	const { getDbName } = require('../general')(app);
+const getAddContainerScript = ddlProvider => container => {
 	const containerData = { ...container.role, name: getDbName(container.role) };
 	const containerLevelData = prepareContainerLevelData(containerData);
 	const hydratedContainer = ddlProvider.hydrateSchema(containerData, containerLevelData);

--- a/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
@@ -2,12 +2,11 @@ const _ = require('lodash');
 const { checkFieldPropertiesChanged, getNames, getBaseAndContainerNames } = require('./common');
 const { createColumnDefinitionBySchema } = require('./createColumnDefinition');
 const { commentIfDeactivated } = require('../commentHelpers/commentDeactivatedHelper');
+const { getEntityName, getFullName, getName, toString } = require('../general');
 
 const getAddCollectionScript =
-	({ ddlProvider, app, scriptFormat }) =>
+	({ ddlProvider, scriptFormat }) =>
 	collection => {
-		const { getEntityName, getName } = require('../general')(app);
-
 		const { schemaName, databaseName } = getBaseAndContainerNames(collection, getName);
 		const jsonSchema = {
 			...collection,
@@ -39,9 +38,7 @@ const getAddCollectionScript =
 		return ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
 	};
 
-const getDeleteCollectionScript = app => collection => {
-	const { getEntityName, getFullName, getName } = require('../general')(app);
-
+const getDeleteCollectionScript = collection => {
 	const jsonData = {
 		...collection,
 		...(_.omit(collection?.role, 'properties') || {}),
@@ -59,10 +56,8 @@ const getModifyCollectionScript = ddlProvider => collection => {
 };
 
 const getAddColumnScript =
-	({ ddlProvider, app, scriptFormat }) =>
+	({ ddlProvider, scriptFormat }) =>
 	collection => {
-		const { getEntityName, getFullName, getName } = require('../general')(app);
-
 		const collectionSchema = {
 			...collection,
 			...(_.omit(collection?.role, 'properties') || {}),
@@ -88,9 +83,7 @@ const getAddColumnScript =
 			);
 	};
 
-const getDeleteColumnScript = app => collection => {
-	const { getEntityName, getFullName, getName } = require('../general')(app);
-
+const getDeleteColumnScript = collection => {
 	const collectionSchema = {
 		...collection,
 		...(_.omit(collection?.role, 'properties') || {}),
@@ -103,8 +96,7 @@ const getDeleteColumnScript = app => collection => {
 		.map(([name]) => `ALTER TABLE IF EXISTS ${fullName} DROP COLUMN ${name};`);
 };
 
-const getModifyColumnScript = app => collection => {
-	const { getEntityName, getFullName, getName, toString } = require('../general')(app);
+const getModifyColumnScript = collection => {
 	const { getSetTagValue, getUnsetTagValue } = require('../../helpers/tagHelper')({ getName, toString });
 
 	const collectionSchema = {

--- a/forward_engineering/helpers/alterScriptHelpers/alterTagHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterTagHelper.js
@@ -1,13 +1,13 @@
 const _ = require('lodash');
 const { prepareContainerLevelData } = require('./common');
+const { getDbName, getName, getGroupItemsByCompMode } = require('../general');
 
 /**
  * @returns {(container: object) => string[]}
  */
 const getAddTagScript =
-	({ ddlProvider, app }) =>
+	({ ddlProvider }) =>
 	container => {
-		const { getDbName, getName } = require('../general')(app);
 		const isCaseSensitive = container.role?.isCaseSensitive;
 		const dbName = getDbName(container.role);
 		const schemaName = getName(isCaseSensitive, dbName);
@@ -21,9 +21,8 @@ const getAddTagScript =
  * @returns {(container: object) => string[]}
  */
 const getDeleteTagScript =
-	({ ddlProvider, app }) =>
+	({ ddlProvider }) =>
 	container => {
-		const { getDbName, getName } = require('../general')(app);
 		const isCaseSensitive = container.role?.isCaseSensitive;
 		const dbName = getDbName(container.role);
 		const schemaName = getName(isCaseSensitive, dbName);
@@ -37,9 +36,8 @@ const getDeleteTagScript =
  * @returns {(container: object) => string[]}
  */
 const getModifyTagScript =
-	({ ddlProvider, app }) =>
+	({ ddlProvider }) =>
 	container => {
-		const { getDbName, getName, getGroupItemsByCompMode } = require('../general')(app);
 		const isCaseSensitive = container.role?.isCaseSensitive;
 		const dbName = getDbName(container.role);
 		const schemaName = getName(isCaseSensitive, dbName);

--- a/forward_engineering/helpers/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterViewHelper.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 const { getNames, getBaseAndContainerNames } = require('./common');
+const { getFullName, getName } = require('../general');
 
-const getViewName = view => (view && view.code) || view.name || '';
+const getViewName = view => view?.code || view.name || '';
 
 const getAddViewScript = (ddlProvider, app) => view => {
-	const { getName } = require('../general')(app);
 	const { mapProperties } = app.require('@hackolade/ddl-fe-utils');
 
 	const { schemaName, databaseName } = getBaseAndContainerNames(view, getName);
@@ -28,9 +28,7 @@ const getAddViewScript = (ddlProvider, app) => view => {
 	return ddlProvider.createView(hydratedView, {}, view.isActivated);
 };
 
-const getDeleteViewScript = app => view => {
-	const { getFullName, getName } = require('../general')(app);
-
+const getDeleteViewScript = view => {
 	const jsonData = {
 		...view,
 		...(_.omit(view?.role, 'properties') || {}),

--- a/forward_engineering/helpers/alterScriptHelpers/commonScript.js
+++ b/forward_engineering/helpers/alterScriptHelpers/commonScript.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 const { escapeString } = require('../../utils/escapeString');
 const { preSpace } = require('../../utils/preSpace');
+const assignTemplates = require('../../utils/assignTemplates');
 
-module.exports = ({ getName, getFullName, templates, assignTemplates, tab }) => {
+module.exports = ({ getName, getFullName, templates, tab }) => {
 	const getSchemaFullName = (database, schemaName, isCaseSensitive) => {
 		const setSchemaName = getName(isCaseSensitive, schemaName);
 		const databaseName = getName(isCaseSensitive, database);

--- a/forward_engineering/helpers/columnDefinitionHelper.js
+++ b/forward_engineering/helpers/columnDefinitionHelper.js
@@ -129,14 +129,23 @@ module.exports = app => {
 		return getPrimaryKey(columnDefinition) + getUnique(columnDefinition);
 	};
 
-	const createExternalColumn = columnDefinition => {
+	const prepareComment = ({ scriptFormat, comment }) => {
+		if (!comment) {
+			return '';
+		}
+		const unescapedDoubleSlashes = comment.replace(/\\\\/g, '\\');
+
+		return preSpace(`COMMENT ${escapeString(scriptFormat, unescapedDoubleSlashes)}`);
+	};
+
+	const createExternalColumn = scriptFormat => columnDefinition => {
 		const externalColumnStatement = assignTemplates(templates.externalColumnDefinition, {
 			name: columnDefinition.name,
 			type: decorateType(columnDefinition.type, columnDefinition),
 			expression: columnDefinition.expression
 				? `(${columnDefinition.expression})`
 				: `(value:${columnDefinition.name}::${columnDefinition.type})`,
-			comment: preSpace(columnDefinition.comment && `COMMENT ${escapeString(columnDefinition.comment)}`),
+			comment: prepareComment({ scriptFormat, comment: columnDefinition.comment }),
 		});
 
 		return { statement: externalColumnStatement, isActivated: columnDefinition.isActivated };
@@ -149,5 +158,6 @@ module.exports = app => {
 		getCollation,
 		getInlineConstraint,
 		createExternalColumn,
+		prepareComment,
 	};
 };

--- a/forward_engineering/helpers/constraintHelper.js
+++ b/forward_engineering/helpers/constraintHelper.js
@@ -1,22 +1,20 @@
-module.exports = app => {
-	const { foreignKeysToString, foreignActiveKeysToString, getName } = require('./general')(app);
+const { foreignKeysToString, foreignActiveKeysToString, getName } = require('./general');
 
-	const generateConstraint = ({ name, keys, keyType, isParentActivated, isCaseSensitive }) => {
-		const keysAsStrings = keys.map(key => ({ ...key, name: `${getName(isCaseSensitive, key.name)}` }));
-		const atLeastOneActive = keysAsStrings.some(key => key.isActivated);
-		let finalStringOfKeys = foreignActiveKeysToString(isCaseSensitive, keysAsStrings);
-		if (atLeastOneActive && isParentActivated) {
-			finalStringOfKeys = foreignKeysToString(isCaseSensitive, keysAsStrings);
-		}
-		return {
-			statement:
-				(name !== 'undefined' ? `CONSTRAINT ${getName(isCaseSensitive, name)} ` : '') +
-				`${keyType} (${finalStringOfKeys})`,
-			isActivated: atLeastOneActive,
-		};
-	};
-
+const generateConstraint = ({ name, keys, keyType, isParentActivated, isCaseSensitive }) => {
+	const keysAsStrings = keys.map(key => ({ ...key, name: `${getName(isCaseSensitive, key.name)}` }));
+	const atLeastOneActive = keysAsStrings.some(key => key.isActivated);
+	let finalStringOfKeys = foreignActiveKeysToString(isCaseSensitive, keysAsStrings);
+	if (atLeastOneActive && isParentActivated) {
+		finalStringOfKeys = foreignKeysToString(isCaseSensitive, keysAsStrings);
+	}
 	return {
-		generateConstraint,
+		statement:
+			(name !== 'undefined' ? `CONSTRAINT ${getName(isCaseSensitive, name)} ` : '') +
+			`${keyType} (${finalStringOfKeys})`,
+		isActivated: atLeastOneActive,
 	};
+};
+
+module.exports = {
+	generateConstraint,
 };

--- a/forward_engineering/helpers/general.js
+++ b/forward_engineering/helpers/general.js
@@ -2,265 +2,265 @@ const _ = require('lodash');
 const assignTemplates = require('../utils/assignTemplates');
 const { commentIfDeactivated } = require('./commentHelpers/commentDeactivatedHelper');
 
-module.exports = app => {
-	const { checkAllKeysActivated } = app.require('@hackolade/ddl-fe-utils').general;
-
-	const escape = value => String(value).replace(/'/g, "''").replace(/\\\\/g, '\\').replace(/\\/g, '\\\\');
-	const toString = value => (_.isUndefined(value) ? value : `'${escape(value)}'`);
-	const isNone = value => _.toLower(value) === 'none';
-	const isAuto = value => _.toLower(value) === 'auto';
-	const toStringIfNotNone = value => (isNone(value) ? value : toString(value));
-	const toStringIfNotAuto = value => (isAuto(value) ? value : toString(value));
-	const toNumber = value => (isNaN(value) ? '' : Number(value));
-	const toBoolean = value => (value === true ? 'TRUE' : undefined);
-	const toOptions = options => {
-		return Object.entries(options)
-			.filter(([__, value]) => !_.isEmpty(value) || value !== false)
-			.map(([optionName, value]) => {
-				if (Array.isArray(value)) {
-					value = '(' + value.filter(value => !_.isEmpty(value)).join(', ') + ')';
-				}
-
-				return `${optionName}=${value}`;
-			})
-			.join('\n');
-	};
-
-	const findJsonSchemaChain = (keyId, jsonSchema, name) => {
-		if (jsonSchema.GUID === keyId) {
-			return [{ ...jsonSchema, name }];
-		} else if (_.isPlainObject(jsonSchema.properties)) {
-			const nestedName = Object.keys(jsonSchema.properties).reduce((result, name) => {
-				if (result.length) {
-					return result;
-				}
-				const nestedName = findJsonSchemaChain(keyId, jsonSchema.properties[name], name);
-
-				if (nestedName) {
-					return result.concat(nestedName);
-				}
-
-				return result;
-			}, []);
-
-			if (nestedName.length) {
-				return [{ ...jsonSchema, name }].concat(nestedName);
+const escape = value => String(value).replace(/'/g, "''").replace(/\\\\/g, '\\').replace(/\\/g, '\\\\');
+const toString = value => (_.isUndefined(value) ? value : `'${escape(value)}'`);
+const isNone = value => _.toLower(value) === 'none';
+const isAuto = value => _.toLower(value) === 'auto';
+const toStringIfNotNone = value => (isNone(value) ? value : toString(value));
+const toStringIfNotAuto = value => (isAuto(value) ? value : toString(value));
+const toNumber = value => (isNaN(value) ? '' : Number(value));
+const toBoolean = value => (value === true ? 'TRUE' : undefined);
+const toOptions = options => {
+	return Object.entries(options)
+		.filter(([__, value]) => !_.isEmpty(value) || value !== false)
+		.map(([optionName, value]) => {
+			if (Array.isArray(value)) {
+				value = '(' + value.filter(value => !_.isEmpty(value)).join(', ') + ')';
 			}
-		} else if (_.isArray(jsonSchema.items)) {
-			const nestedName = jsonSchema.items.reduce((result, schema) => {
-				if (result.length) {
-					return result;
-				}
-				const nestedName = findJsonSchemaChain(keyId, schema, '');
 
-				if (nestedName) {
-					return result.concat(nestedName);
-				}
+			return `${optionName}=${value}`;
+		})
+		.join('\n');
+};
 
+const findJsonSchemaChain = (keyId, jsonSchema, name) => {
+	if (jsonSchema.GUID === keyId) {
+		return [{ ...jsonSchema, name }];
+	} else if (_.isPlainObject(jsonSchema.properties)) {
+		const nestedName = Object.keys(jsonSchema.properties).reduce((result, name) => {
+			if (result.length) {
 				return result;
-			}, []);
-
-			if (nestedName.length) {
-				return [{ ...jsonSchema, name }].concat(nestedName);
 			}
-		} else if (jsonSchema.items) {
-			const nestedName = findJsonSchemaChain(keyId, jsonSchema.items, '');
+			const nestedName = findJsonSchemaChain(keyId, jsonSchema.properties[name], name);
 
 			if (nestedName) {
-				return [{ ...jsonSchema, name }].concat(nestedName);
+				return result.concat(nestedName);
 			}
+
+			return result;
+		}, []);
+
+		if (nestedName.length) {
+			return [{ ...jsonSchema, name }].concat(nestedName);
 		}
-	};
+	} else if (_.isArray(jsonSchema.items)) {
+		const nestedName = jsonSchema.items.reduce((result, schema) => {
+			if (result.length) {
+				return result;
+			}
+			const nestedName = findJsonSchemaChain(keyId, schema, '');
 
-	const composeClusteringKey = (isCaseSensitive, jsonSchema, clusteringKey) => {
-		const name = _.get(clusteringKey, 'clusteringKey[0].name', '');
-		const isActivated = _.get(clusteringKey, 'clusteringKey[0].isActivated', true);
-		const isComplexName = name => String(name || '').includes('.');
+			if (nestedName) {
+				return result.concat(nestedName);
+			}
 
-		if (clusteringKey.expression) {
+			return result;
+		}, []);
+
+		if (nestedName.length) {
+			return [{ ...jsonSchema, name }].concat(nestedName);
+		}
+	} else if (jsonSchema.items) {
+		const nestedName = findJsonSchemaChain(keyId, jsonSchema.items, '');
+
+		if (nestedName) {
+			return [{ ...jsonSchema, name }].concat(nestedName);
+		}
+	}
+};
+
+const composeClusteringKey = (isCaseSensitive, jsonSchema, clusteringKey) => {
+	const name = _.get(clusteringKey, 'clusteringKey[0].name', '');
+	const isActivated = _.get(clusteringKey, 'clusteringKey[0].isActivated', true);
+	const isComplexName = name => String(name || '').includes('.');
+
+	if (clusteringKey.expression) {
+		return {
+			name: assignTemplates(clusteringKey.expression, { name: getName(isCaseSensitive, name) }),
+			isActivated,
+			isExpression: true,
+		};
+	} else if (name && !isComplexName(name)) {
+		return { name, isActivated };
+	} else {
+		const keyId = _.get(clusteringKey, 'clusteringKey[0].keyId', '');
+		const name = findJsonSchemaChain(keyId, jsonSchema);
+
+		if (Array.isArray(name)) {
+			const type = _.get(name[name.length - 1], 'type', '')
+				.replace(/json/i, '')
+				.toLowerCase();
 			return {
-				name: assignTemplates(clusteringKey.expression, { name: getName(isCaseSensitive, name) }),
+				name: `(${name
+					.map(schema => getName(isCaseSensitive, schema.name))
+					.filter(Boolean)
+					.join(':')}::${type})`,
 				isActivated,
 				isExpression: true,
 			};
-		} else if (name && !isComplexName(name)) {
-			return { name, isActivated };
-		} else {
-			const keyId = _.get(clusteringKey, 'clusteringKey[0].keyId', '');
-			const name = findJsonSchemaChain(keyId, jsonSchema);
-
-			if (Array.isArray(name)) {
-				const type = _.get(name[name.length - 1], 'type', '')
-					.replace(/json/i, '')
-					.toLowerCase();
-				return {
-					name: `(${name
-						.map(schema => getName(isCaseSensitive, schema.name))
-						.filter(Boolean)
-						.join(':')}::${type})`,
-					isActivated,
-					isExpression: true,
-				};
-			}
 		}
-	};
+	}
+};
 
-	const foreignKeysToString = (isCaseSensitive, keys) => {
-		if (Array.isArray(keys)) {
-			const splitter = ', ';
-			let deactivatedKeys = [];
-			const processedKeys = keys
-				.reduce((keysString, key) => {
-					let keyName = _.isString(key.name) ? key.name.trim() : key.trim();
-					if (!key.isExpression) {
-						keyName = getName(isCaseSensitive, keyName);
-					}
+const foreignKeysToString = (isCaseSensitive, keys) => {
+	if (Array.isArray(keys)) {
+		const splitter = ', ';
+		let deactivatedKeys = [];
+		const processedKeys = keys
+			.reduce((keysString, key) => {
+				let keyName = _.isString(key.name) ? key.name.trim() : key.trim();
+				if (!key.isExpression) {
+					keyName = getName(isCaseSensitive, keyName);
+				}
 
-					if (!_.get(key, 'isActivated', true)) {
-						deactivatedKeys.push(keyName);
+				if (!_.get(key, 'isActivated', true)) {
+					deactivatedKeys.push(keyName);
 
-						return keysString;
-					}
+					return keysString;
+				}
 
-					return [...keysString, keyName];
-				}, [])
-				.filter(Boolean);
+				return [...keysString, keyName];
+			}, [])
+			.filter(Boolean);
 
-			if (processedKeys.length === 0) {
-				return commentIfDeactivated(deactivatedKeys.join(splitter), { isActivated: false }, true);
-			} else if (deactivatedKeys.length === 0) {
-				return processedKeys.join(splitter);
-			}
-
-			return (
-				processedKeys.join(splitter) +
-				commentIfDeactivated(splitter + deactivatedKeys.join(splitter), { isActivated: false }, true)
-			);
-		}
-		return keys;
-	};
-
-	const foreignActiveKeysToString = (isCaseSensitive, keys) => {
-		return keys?.map(key => getName(isCaseSensitive, key.name.trim())).join(', ');
-	};
-
-	const checkIfForeignKeyActivated = fkData =>
-		checkAllKeysActivated(fkData.foreignKey) &&
-		checkAllKeysActivated(fkData.primaryKey) &&
-		fkData.primaryTableActivated &&
-		fkData.foreignTableActivated;
-
-	const viewColumnsToString = (keys, isParentActivated) => {
-		const mergeCommentWithName = ({ name, comment }) => (comment ? `${name}${comment}` : name);
-
-		if (!isParentActivated) {
-			return keys.map(mergeCommentWithName).join(',\n\t');
-		}
-
-		const activatedKeys = keys.filter(key => key.isActivated).map(mergeCommentWithName);
-		const deactivatedKeys = keys.filter(key => !key.isActivated).map(mergeCommentWithName);
-
-		if (activatedKeys.length === 0) {
-			return commentIfDeactivated(deactivatedKeys.join(',\n\t'), { isActivated: false }, true);
-		}
-		if (deactivatedKeys.length === 0) {
-			return activatedKeys.join(',\n\t');
+		if (processedKeys.length === 0) {
+			return commentIfDeactivated(deactivatedKeys.join(splitter), { isActivated: false }, true);
+		} else if (deactivatedKeys.length === 0) {
+			return processedKeys.join(splitter);
 		}
 
 		return (
-			activatedKeys.join(',\n\t') +
-			'\n\t' +
-			commentIfDeactivated(deactivatedKeys.join(',\n\t'), { isActivated: false }, true)
+			processedKeys.join(splitter) +
+			commentIfDeactivated(splitter + deactivatedKeys.join(splitter), { isActivated: false }, true)
 		);
-	};
+	}
+	return keys;
+};
 
-	const getName = (isCaseSensitive, name) => {
-		if (!name) {
-			return name;
+const foreignActiveKeysToString = (isCaseSensitive, keys) => {
+	return keys?.map(key => getName(isCaseSensitive, key.name.trim())).join(', ');
+};
+
+const checkAllKeysActivated = keys => {
+	return keys.every(key => _.get(key, 'isActivated', true));
+};
+
+const checkIfForeignKeyActivated = fkData =>
+	checkAllKeysActivated(fkData.foreignKey) &&
+	checkAllKeysActivated(fkData.primaryKey) &&
+	fkData.primaryTableActivated &&
+	fkData.foreignTableActivated;
+
+const viewColumnsToString = (keys, isParentActivated) => {
+	const mergeCommentWithName = ({ name, comment }) => (comment ? `${name}${comment}` : name);
+
+	if (!isParentActivated) {
+		return keys.map(mergeCommentWithName).join(',\n\t');
+	}
+
+	const activatedKeys = keys.filter(key => key.isActivated).map(mergeCommentWithName);
+	const deactivatedKeys = keys.filter(key => !key.isActivated).map(mergeCommentWithName);
+
+	if (activatedKeys.length === 0) {
+		return commentIfDeactivated(deactivatedKeys.join(',\n\t'), { isActivated: false }, true);
+	}
+	if (deactivatedKeys.length === 0) {
+		return activatedKeys.join(',\n\t');
+	}
+
+	return (
+		activatedKeys.join(',\n\t') +
+		'\n\t' +
+		commentIfDeactivated(deactivatedKeys.join(',\n\t'), { isActivated: false }, true)
+	);
+};
+
+const getName = (isCaseSensitive, name) => {
+	if (!name) {
+		return name;
+	}
+
+	if (isCaseSensitive) {
+		return addQuotes(name);
+	}
+
+	return isValidCaseInsensitiveName(name) ? name : addQuotes(name);
+};
+
+const getEntityName = entityData => {
+	return (entityData && (entityData.code || entityData.collectionName)) || '';
+};
+
+const getFullName = (schemaName, name) => {
+	if (!schemaName) {
+		return name;
+	}
+
+	return `${schemaName}.${name}`;
+};
+
+const isValidCaseInsensitiveName = name => {
+	return /^[a-z_][a-z\d_$]*$/i.test(name);
+};
+
+const addQuotes = string => {
+	if (/^".*"$/.test(string)) {
+		return string;
+	}
+
+	return `"${string}"`;
+};
+
+const getDbName = containerData => {
+	return _.get(containerData, 'code') || _.get(containerData, 'name', '');
+};
+
+/**
+ * @template T
+ * @param {{ newItems: T[], oldItems: T[] }}
+ * @returns {{ addedItems: T[], removedItems: T[], modifiedItems: T[] }}
+ */
+const getGroupItemsByCompMode = ({ newItems = [], oldItems = [] }) => {
+	const addedItems = newItems.filter(newItem => !oldItems.some(item => item.id === newItem.id));
+	const removedItems = [];
+	const modifiedItems = [];
+
+	oldItems.forEach(oldItem => {
+		const newItem = newItems.find(item => item.id === oldItem.id);
+
+		if (!newItem) {
+			removedItems.push(oldItem);
+		} else if (!_.isEqual(newItem, oldItem)) {
+			modifiedItems.push(newItem);
 		}
-
-		if (isCaseSensitive) {
-			return addQuotes(name);
-		}
-
-		return isValidCaseInsensitiveName(name) ? name : addQuotes(name);
-	};
-
-	const getEntityName = entityData => {
-		return (entityData && (entityData.code || entityData.collectionName)) || '';
-	};
-
-	const getFullName = (schemaName, name) => {
-		if (!schemaName) {
-			return name;
-		}
-
-		return `${schemaName}.${name}`;
-	};
-
-	const isValidCaseInsensitiveName = name => {
-		return /^[a-z_][a-z\d_$]*$/i.test(name);
-	};
-
-	const addQuotes = string => {
-		if (/^".*"$/.test(string)) {
-			return string;
-		}
-
-		return `"${string}"`;
-	};
-
-	const getDbName = containerData => {
-		return _.get(containerData, 'code') || _.get(containerData, 'name', '');
-	};
-
-	/**
-	 * @template T
-	 * @param {{ newItems: T[], oldItems: T[] }}
-	 * @returns {{ addedItems: T[], removedItems: T[], modifiedItems: T[] }}
-	 */
-	const getGroupItemsByCompMode = ({ newItems = [], oldItems = [] }) => {
-		const addedItems = newItems.filter(newItem => !oldItems.some(item => item.id === newItem.id));
-		const removedItems = [];
-		const modifiedItems = [];
-
-		oldItems.forEach(oldItem => {
-			const newItem = newItems.find(item => item.id === oldItem.id);
-
-			if (!newItem) {
-				removedItems.push(oldItem);
-			} else if (!_.isEqual(newItem, oldItem)) {
-				modifiedItems.push(newItem);
-			}
-		});
-
-		return {
-			added: addedItems,
-			removed: removedItems,
-			modified: modifiedItems,
-		};
-	};
+	});
 
 	return {
-		escape,
-		toString,
-		isNone,
-		isAuto,
-		toStringIfNotNone,
-		toStringIfNotAuto,
-		toNumber,
-		toBoolean,
-		toOptions,
-		composeClusteringKey,
-		foreignKeysToString,
-		checkIfForeignKeyActivated,
-		foreignActiveKeysToString,
-		viewColumnsToString,
-		getName,
-		getEntityName,
-		getFullName,
-		getDbName,
-		addQuotes,
-		getGroupItemsByCompMode,
+		added: addedItems,
+		removed: removedItems,
+		modified: modifiedItems,
 	};
+};
+
+module.exports = {
+	escape,
+	toString,
+	isNone,
+	isAuto,
+	toStringIfNotNone,
+	toStringIfNotAuto,
+	toNumber,
+	toBoolean,
+	toOptions,
+	composeClusteringKey,
+	foreignKeysToString,
+	checkIfForeignKeyActivated,
+	foreignActiveKeysToString,
+	viewColumnsToString,
+	getName,
+	getEntityName,
+	getFullName,
+	getDbName,
+	addQuotes,
+	getGroupItemsByCompMode,
 };

--- a/forward_engineering/helpers/getFormatTypeOptions.js
+++ b/forward_engineering/helpers/getFormatTypeOptions.js
@@ -1,11 +1,10 @@
 const _ = require('lodash');
+const { toString, toStringIfNotNone, toStringIfNotAuto, toNumber, toBoolean } = require('./general');
 
 const getNullIf = nullIfOptions =>
-	Array.isArray(nullIfOptions) ? nullIfOptions.filter(item => item && item['NULL_IF_item']) : [];
+	Array.isArray(nullIfOptions) ? nullIfOptions.filter(item => item?.['NULL_IF_item']) : [];
 
-const getFormatTypeOptions = app => (fileFormat, formatOptions) => {
-	const { toString, toStringIfNotNone, toStringIfNotAuto, toNumber, toBoolean } = require('./general')(app);
-
+const getFormatTypeOptions = (fileFormat, formatOptions) => {
 	switch (fileFormat) {
 		case 'CSV':
 			return {

--- a/forward_engineering/helpers/getStageCopyOptions.js
+++ b/forward_engineering/helpers/getStageCopyOptions.js
@@ -1,33 +1,28 @@
-module.exports = app => {
-	const { toNumber, toBoolean } = require('./general')(app);
+const { toNumber, toBoolean } = require('./general');
 
-	const getOnError = properties => {
-		if (properties.ON_ERROR === 'SKIP_FILE_<num>') {
-			return `SKIP_FILE_${properties.skipFileNum}`;
-		} else if (properties.ON_ERROR === 'SKIP_FILE_<num>%') {
-			return `SKIP_FILE_${properties.skipFileNumPct}%`;
-		}
+const getOnError = properties => {
+	if (properties.ON_ERROR === 'SKIP_FILE_<num>') {
+		return `SKIP_FILE_${properties.skipFileNum}`;
+	} else if (properties.ON_ERROR === 'SKIP_FILE_<num>%') {
+		return `SKIP_FILE_${properties.skipFileNumPct}%`;
+	}
 
-		return properties.ON_ERROR;
-	};
+	return properties.ON_ERROR;
+};
 
-	const getStageCopyOptions = properties => {
-		return {
-			ON_ERROR: getOnError(properties),
-			SIZE_LIMIT: properties.sizeLimit ? toNumber(properties.SIZE_LIMIT) : undefined,
-			PURGE: toBoolean(properties.PURGE),
-			MATCH_BY_COLUMN_NAME: properties.MATCH_BY_COLUMN_NAME,
-			ENFORCE_LENGTH: toBoolean(properties.ENFORCE_LENGTH),
-			RETURN_FAILED_ONLY: toBoolean(properties.RETURN_FAILED_ONLY),
-			TRUNCATECOLUMNS: toBoolean(properties.TRUNCATECOLUMNS),
-			LOAD_UNCERTAIN_FILES: !properties.LOAD_UNCERTAIN_FILES
-				? undefined
-				: toBoolean(properties.LOAD_UNCERTAIN_FILES),
-			FORCE: toBoolean(properties.FORCE),
-		};
-	};
-
+const getStageCopyOptions = properties => {
 	return {
-		getStageCopyOptions,
+		ON_ERROR: getOnError(properties),
+		SIZE_LIMIT: properties.sizeLimit ? toNumber(properties.SIZE_LIMIT) : undefined,
+		PURGE: toBoolean(properties.PURGE),
+		MATCH_BY_COLUMN_NAME: properties.MATCH_BY_COLUMN_NAME,
+		ENFORCE_LENGTH: toBoolean(properties.ENFORCE_LENGTH),
+		RETURN_FAILED_ONLY: toBoolean(properties.RETURN_FAILED_ONLY),
+		TRUNCATECOLUMNS: toBoolean(properties.TRUNCATECOLUMNS),
+		LOAD_UNCERTAIN_FILES: !properties.LOAD_UNCERTAIN_FILES ? undefined : toBoolean(properties.LOAD_UNCERTAIN_FILES),
+		FORCE: toBoolean(properties.FORCE),
 	};
+};
+module.exports = {
+	getStageCopyOptions,
 };

--- a/forward_engineering/helpers/keyHelper.js
+++ b/forward_engineering/helpers/keyHelper.js
@@ -4,10 +4,10 @@
  * @typedef {import('forward_engineering/types').ConstraintDto} ConstraintDto
  */
 const _ = require('lodash');
+const { addQuotes } = require('./general');
 
 module.exports = app => {
 	const { clean } = app.require('@hackolade/ddl-fe-utils').general;
-	const { addQuotes } = require('./general')(app);
 
 	const mapProperties = (jsonSchema, iteratee) => {
 		return Object.entries(jsonSchema.properties).map(iteratee);

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -1,9 +1,9 @@
 const { isEmpty, toUpper, trim } = require('lodash');
 const { preSpace } = require('../utils/preSpace');
+const { toOptions } = require('./general');
 
 module.exports = app => {
 	const { tab } = app.require('@hackolade/ddl-fe-utils').general;
-	const { toOptions } = require('./general')(app);
 
 	const getFileFormat = (fileFormat, formatTypeOptions, formatName = '') => {
 		if (fileFormat !== 'custom') {

--- a/forward_engineering/utils/escapeString.js
+++ b/forward_engineering/utils/escapeString.js
@@ -1,7 +1,7 @@
 const { FORMATS } = require('../helpers/constants');
 
 const MUST_BE_ESCAPED =
-	/(\\r|\\n|\\b|\\f|\\t|'|"|\\[0-9]{3}|\0|\\x5C[0-3]?[0-7]{1,2}|\x5C[xX][0-9A-Fa-f]{2}|\x5C[uU][0-9A-Fa-f]{4}|\\)/g;
+	/(?<!\\)(\\r|\\n|\\b|\\f|\\t|'|"|\\[0-9]{3}|\0|\\x5C[0-3]?[0-7]{1,2}|\x5C[xX][0-9A-Fa-f]{2}|\x5C[uU][0-9A-Fa-f]{4})/g;
 
 const escapeString = (scriptFormat, value) =>
 	scriptFormat === FORMATS.SNOWSIGHT ? `'${value.replace(MUST_BE_ESCAPED, '\\$1')}'` : `$$${value}$$`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10107" title="HCK-10107" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10107</a>  Improve character escaping in comments when character are already escaped
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* [make sure](https://github.com/hackolade/Snowflake/compare/fix/HCK-10107-fe-already-escaped-comments?expand=1#diff-6372fa654db091ebf414449305159b422839fe0b48ca6d4d9d85440b16ed59d2R4) that the character wasn't escaped already with `(?<!\\)` and excluding single slash from regexp:

![image](https://github.com/user-attachments/assets/bdee3d65-bd55-4144-ace3-d596ea48d2f1)

![image](https://github.com/user-attachments/assets/76bf4680-46de-46f0-8243-b5d04a5d7cc7)


* the rest is mostly chores, eliminating redundant dependencies