### PR TITLE
HCK-10442: add max length for varchar and binary. Add adapter config to properlt handle hasMaxLength property on conversion

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -1,10 +1,4 @@
 /**
- * Copyright © 2016-2022 by IntegrIT S.A. dba Hackolade.  All rights reserved.
- *
- * The copyright to the computer software herein is the property of IntegrIT S.A.
- * The software may be used and/or copied only with the written permission of
- * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
- * the agreement/contract under which the software has been supplied.
  *
  * {
  * 		"add": {
@@ -42,39 +36,32 @@
 {
 	"modify": {
 		"field": [
-			[
-				"renameBlockItemProperties",
-				{
-					"identity": {
-						"self": "autoincrement"
-					}
-				}
-			],
 			{
 				"from": {
-					"defaultOption": "Identity"
+					"type": "varchar",
+					"hasMaxLength": true
 				},
 				"to": {
-					"defaultOption": "Autoincrement"
+					"length": 16777216
 				}
 			},
 			{
 				"from": {
-					"childType": "varchar",
-					"length": 16777216
+					"type": "nvarchar",
+					"hasMaxLength": true
 				},
 				"to": {
-					"hasMaxLength": true
+					"length": 16777216
 				}
 			},
 			{
 				"from": {
 					"type": "binary",
 					"mode": "varbinary",
-					"length": 8388608
+					"hasMaxLength": true
 				},
 				"to": {
-					"hasMaxLength": true
+					"numChar": 8388608
 				}
 			}
 		]

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -142,7 +142,8 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "numeric",
 				"valueType": "number",
 				"allowNegative": false,
-				"typeDecorator": true
+				"typeDecorator": true,
+				"maxValue": 16777216
 			},
 			{
 				"propertyName": "Column expression",
@@ -3422,7 +3423,8 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "numChar",
 				"propertyType": "numeric",
 				"valueType": "number",
-				"allowNegative": false
+				"allowNegative": false,
+				"maxValue": 8388608
 			},
 			{
 				"propertyName": "Column expression",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added max length for varchar and binary. Add adapter config to properlt handle hasMaxLength property on conversion