### PR TITLE
HCK-10580: Add line brake after cluster by clause

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -316,7 +316,7 @@ module.exports = (baseProvider, options, app) => {
 						(isActivated
 							? foreignKeysToString(tableData.isCaseSensitive, tableData.clusteringKey)
 							: foreignActiveKeysToString(tableData.isCaseSensitive, tableData.clusteringKey)) +
-						')\n',
+						')',
 			);
 			const partitionKeys = preSpace(
 				!isEmpty(tableData.partitioningKey) &&

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -316,7 +316,7 @@ module.exports = (baseProvider, options, app) => {
 						(isActivated
 							? foreignKeysToString(tableData.isCaseSensitive, tableData.clusteringKey)
 							: foreignActiveKeysToString(tableData.isCaseSensitive, tableData.clusteringKey)) +
-						')',
+						')\n',
 			);
 			const partitionKeys = preSpace(
 				!isEmpty(tableData.partitioningKey) &&

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -111,7 +111,7 @@ module.exports = app => {
 			column_definitions: columnDefinitions ? `\t(\n\t\t${columnDefinitions}\n\t)\n` : '',
 			refreshMode: refreshMode ? `REFRESH_MODE = ${refreshMode}\n` : '',
 			initialize: initialize ? `INITIALIZE = ${initialize}\n` : '',
-			clusterKeys,
+			clusterKeys: clusterKeys ? `${clusterKeys}\n` : '',
 			dataRetentionTime: dataRetentionTime ? `${dataRetentionTime.trim()}\n` : '',
 			maxDataExtensionTime: maxDataExtensionTime
 				? `MAX_DATA_EXTENSION_TIME_IN_DAYS = ${maxDataExtensionTime}\n`

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -111,7 +111,7 @@ module.exports = app => {
 			column_definitions: columnDefinitions ? `\t(\n\t\t${columnDefinitions}\n\t)\n` : '',
 			refreshMode: refreshMode ? `REFRESH_MODE = ${refreshMode}\n` : '',
 			initialize: initialize ? `INITIALIZE = ${initialize}\n` : '',
-			clusterKeys: clusterKeys ? `${clusterKeys}\n` : '',
+			clusterKeys: clusterKeys ? `${clusterKeys.trim()}\n` : '',
 			dataRetentionTime: dataRetentionTime ? `${dataRetentionTime.trim()}\n` : '',
 			maxDataExtensionTime: maxDataExtensionTime
 				? `MAX_DATA_EXTENSION_TIME_IN_DAYS = ${maxDataExtensionTime}\n`


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10580" title="HCK-10580" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10580</a>  FE: missing space in DDL leading to error with cluster by, followed by select as statement
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Table extra props: Add a line break after the cluster by clause
