### PR TITLE
HCK-10586: Add escpaing braces for ipv6 host

### DIFF
--- a/reverse_engineering/helpers/escapeUrlIpV6WithBraces.js
+++ b/reverse_engineering/helpers/escapeUrlIpV6WithBraces.js
@@ -1,0 +1,47 @@
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isValidURL(url) {
+	try {
+		new URL(url);
+
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * In case URL includes ip version 6 we need to escape the ip portion with square brackets before adding a port
+ *
+ * @param {{
+ * 	url: string
+ * }} param
+ * @returns {string}
+ */
+function escapeUrlIpV6WithBraces({ url }) {
+	const isUrlValid = isValidURL(url);
+
+	if (isUrlValid) {
+		return url;
+	}
+
+	const urlWithIpV6HostRegExp = new RegExp(/^http(s)?:\/\/(?<unescapedIpWithPort>([a-z0-9]{0,4}:?)+)/gim);
+	const { unescapedIpWithPort } = urlWithIpV6HostRegExp.exec(url)?.groups ?? {};
+
+	if (!unescapedIpWithPort) {
+		return url;
+	}
+
+	const separatedIpPortionsAndPort = unescapedIpWithPort.split(':');
+	const ipPortions = separatedIpPortionsAndPort.slice(0, separatedIpPortionsAndPort.length - 1);
+	const port = separatedIpPortionsAndPort.at(-1);
+	const escapedIpWithPort = `[${ipPortions.join(':')}]:${port}`;
+
+	return url.replace(unescapedIpWithPort, escapedIpWithPort);
+}
+
+module.exports = {
+	escapeUrlIpV6WithBraces,
+};

--- a/reverse_engineering/helpers/snowflakeHelper.js
+++ b/reverse_engineering/helpers/snowflakeHelper.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const uuid = require('uuid');
 const BSON = require('bson');
 const errorMessages = require('./errorMessages');
+const { escapeUrlIpV6WithBraces } = require('./escapeUrlIpV6WithBraces');
 
 const ALREADY_CONNECTED_STATUS = 405502;
 const CANT_REACH_SNOWFLAKE_ERROR_STATUS = 401001;
@@ -422,11 +423,12 @@ const getConnectionTimeoutError = timeout => {
 	return error;
 };
 
-const getAccount = hostUrl =>
-	(hostUrl || '')
-		.trim()
-		.replace(/\.snowflakecomputing\.com.*$/gi, '')
-		.replace(/^http(s)?:\/\//gi, '');
+const getAccount = hostUrl => {
+	const rawHostUrl = (hostUrl || '').trim();
+	const hostWithEscapedIp = escapeUrlIpV6WithBraces({ url: rawHostUrl });
+
+	return hostWithEscapedIp.replace(/\.snowflakecomputing\.com.*$/gi, '').replace(/^http(s)?:\/\//gi, '');
+};
 
 const getRole = role => {
 	if (!_.isString(role)) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10586" title="HCK-10586" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-10586</a>  [Social Security Admin] Enclose ipv6 addresses in URLs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added escaping braces for ipv6 host