### PR TITLE
HCK-11336: fix variant data type conversion to polyglot

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -79,8 +79,7 @@
 			},
 			{
 				"from": {
-					"type": "document",
-					"childType": "variant"
+					"type": "variant"
 				},
 				"to": {
 					"type": "binary",

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -76,6 +76,17 @@
 				"to": {
 					"hasMaxLength": true
 				}
+			},
+			{
+				"from": {
+					"type": "document",
+					"childType": "variant"
+				},
+				"to": {
+					"type": "binary",
+					"childType": "blob",
+					"mode": "variant"
+				}
 			}
 		]
 	}

--- a/types/variant.json
+++ b/types/variant.json
@@ -10,6 +10,7 @@
 		"name": "variant",
 		"jsonRoot": true
 	},
+	"restrictNormalization": true,
 	"defaultValues": {
 		"primaryKey": false,
 		"mode": "var",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11336" title="HCK-11336" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11336</a>  Incorrect conversion of variant data type to Polyglot
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
