### PR TITLE
Revert "HCK-11336: fix variant data type conversion to polyglot (#194)"

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -76,16 +76,6 @@
 				"to": {
 					"hasMaxLength": true
 				}
-			},
-			{
-				"from": {
-					"type": "variant"
-				},
-				"to": {
-					"type": "binary",
-					"childType": "blob",
-					"mode": "variant"
-				}
 			}
 		]
 	}

--- a/types/variant.json
+++ b/types/variant.json
@@ -10,7 +10,6 @@
 		"name": "variant",
 		"jsonRoot": true
 	},
-	"restrictNormalization": true,
 	"defaultValues": {
 		"primaryKey": false,
 		"mode": "var",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11336" title="HCK-11336" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11336</a>  Incorrect conversion of variant data type to Polyglot
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This reverts commit cc5d46741fa295b30e5fdd7ea4153e3a464e9fdd.
