### PR TITLE
HCK-11441: fix conversion of object and array to Polyglot

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -79,12 +79,20 @@
 			},
 			{
 				"from": {
-					"type": "variant"
+					"type": "object"
 				},
 				"to": {
-					"type": "binary",
-					"childType": "blob",
-					"mode": "variant"
+					"type": "object",
+					"subtype": ""
+				}
+			},
+			{
+				"from": {
+					"type": "array"
+				},
+				"to": {
+					"type": "array",
+					"subtype": ""
 				}
 			}
 		]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11441" title="HCK-11441" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11441</a>  [Snowflake][Conver to Poly] Object / Array datatypes incorrectly converted to 'blob>json' 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

`object` should be convert to Polyglot's `object`

`array` should be convert to Polyglot's `array`