### PR TITLE
HCK-12005: add ifNotExist and orReplace properties to views; HCK-12006: fix RE from DDL of ifNotExist for table

### DIFF
--- a/adapter/0.2.30.json
+++ b/adapter/0.2.30.json
@@ -1,0 +1,74 @@
+/**
+ * Copyright © 2016-2018 by IntegrIT S.A. dba Hackolade.  All rights reserved.
+ *
+ * The copyright to the computer software herein is the property of IntegrIT S.A.
+ * The software may be used and/or copied only with the written permission of
+ * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+ * the agreement/contract under which the software has been supplied.
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+{
+	"add": {
+		"view": [
+			{
+				"path": ["ifNotExist"],
+				"value": true
+			}
+		]
+	},
+	"modify": {
+		"entity": [
+			{
+				"from": {
+					"tableIfNotExists": true
+				},
+				"to": {
+					"ifNotExist": true
+				}
+			},
+			{
+				"from": {
+					"tableIfNotExists": false
+				},
+				"to": {
+					"ifNotExist": false
+				}
+			}
+		]
+	},
+	"delete": {
+		"entity": ["tableIfNotExists"]
+	}
+}

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -63,7 +63,7 @@ module.exports = {
 		'ALTER TABLE IF EXISTS ${table_name} ADD ${constraint}FOREIGN KEY (${columns}) REFERENCES ${primary_table} (${primary_columns});',
 
 	createView:
-		'CREATE${secure}${materialized} VIEW IF NOT EXISTS ${name} (\n' +
+		'CREATE${orReplace}${secure}${materialized} VIEW${ifNotExist} ${name} (\n' +
 		'\t${column_list}\n' +
 		')\n${copy_grants}${comment}${tag}${clustering}AS ${select_statement};\n',
 

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -557,6 +557,8 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createView(viewData, dbData, isActivated) {
+			const orReplace = preSpace(viewData.orReplace && 'OR REPLACE');
+			const ifNotExist = preSpace(viewData.ifNotExist && 'IF NOT EXISTS');
 			const schemaName = get(viewData, 'schemaData.schemaName');
 			const { columnList, tableColumns, tables } = viewData.keys.reduce(
 				(result, key) => {
@@ -618,6 +620,8 @@ module.exports = (baseProvider, options, app) => {
 				: undefined;
 
 			return assignTemplates(templates.createView, {
+				orReplace,
+				ifNotExist,
 				secure: preSpace(viewData.secure && 'SECURE'),
 				materialized: preSpace(viewData.materialized && 'MATERIALIZED'),
 				name: getFullName(schemaName, viewData.name),
@@ -887,7 +891,7 @@ module.exports = (baseProvider, options, app) => {
 				dynamic: firstTab.dynamic,
 				iceberg: firstTab.iceberg,
 				orReplace: firstTab.orReplace,
-				tableIfNotExists: firstTab.tableIfNotExists,
+				tableIfNotExists: firstTab.ifNotExist,
 				tableExtraProps: {
 					warehouse: firstTab.warehouse,
 					targetLag: firstTab.targetLag,
@@ -988,6 +992,8 @@ module.exports = (baseProvider, options, app) => {
 
 			return {
 				...viewData,
+				orReplace: firstTab.orReplace,
+				ifNotExist: firstTab.ifNotExist,
 				name: getName(firstTab.isCaseSensitive, viewData.name),
 				selectStatement: firstTab.selectStatement,
 				isCaseSensitive: firstTab.isCaseSensitive,

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -173,13 +173,13 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "orReplace",
 				"propertyType": "checkbox",
 				"disabledOnCondition": {
-					"key": "tableIfNotExists",
+					"key": "ifNotExist",
 					"value": true
 				}
 			},
 			{
 				"propertyName": "If not exist",
-				"propertyKeyword": "tableIfNotExists",
+				"propertyKeyword": "ifNotExist",
 				"propertyTooltip": "if the specified table already exists, the command should make no changes and return a message that the table exists, rather than terminating with an error. ",
 				"propertyType": "checkbox",
 				"disabledOnCondition": {

--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -53,6 +53,25 @@
 				"hidden": true
 			},
 			{
+				"propertyName": "Or replace",
+				"propertyKeyword": "orReplace",
+				"propertyType": "checkbox",
+				"disabledOnCondition": {
+					"key": "ifNotExist",
+					"value": true
+				}
+			},
+			{
+				"propertyName": "If not exist",
+				"propertyKeyword": "ifNotExist",
+				"propertyTooltip": "If the specified view already exists, the command should make no changes and return a message that the view exists, rather than terminating with an error.",
+				"propertyType": "checkbox",
+				"disabledOnCondition": {
+					"key": "orReplace",
+					"value": true
+				}
+			},
+			{
 				"propertyName": "Materialized",
 				"propertyKeyword": "materialized",
 				"shouldValidate": false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12005" title="HCK-12005" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12005</a>  Allow usage IF NOT EXISTS and OR REPLACE in views
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added support for `OR REPLACE` and `IF NOT EXIST` for views.

Fixed RE of `IF NOT EXIST` for table from DDL. It was not working because the wrong keyword was used.

Added an adapter to still have `IF NOT EXIST` in FE for views as it was before, and to fix the keyword of table.