### PR TITLE
HCK-12277: hide passphrase on UI

### DIFF
--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -180,7 +180,7 @@
 			{
 				"inputLabel": "Passphrase",
 				"inputKeyword": "privateKeyPass",
-				"inputType": "text",
+				"inputType": "password",
 				"inputTooltip": "Optional entry. Passphrase to the private key",
 				"defaultValue": "",
 				"dependency": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12277" title="HCK-12277" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12277</a>  [Snowflake][Key-pair] Passphrase should be a pass-field (hidden with asterisks by default
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Hide passphrase on UI