### PR TITLE
HCK-12309: change error message in case of invalid username provided

### DIFF
--- a/common/errorMessages.js
+++ b/common/errorMessages.js
@@ -5,5 +5,6 @@ module.exports = {
 		'Incorrect Okta username/password or MFA is enabled. Please, check credentials or use the "Identity Provider SSO (via external browser)" for MFA auth',
 	OKTA_MFA_ERROR:
 		'Native Okta auth doesn\'t support MFA. Please, use the "Identity Provider SSO (via external browser)" auth instead',
-	KEY_PAIR_ERROR: 'Please check that the passphrase is provided and matches the key.',
+	KEY_PAIR_PASSPHRASE_ERROR: 'Please check that the passphrase is provided and matches the key.',
+	KEY_PAIR_USERNAME_ERROR: 'Incorrect username was specified.',
 };

--- a/common/getKeyPairConnectionErrorMessageByCode.js
+++ b/common/getKeyPairConnectionErrorMessageByCode.js
@@ -2,9 +2,9 @@ const errorMessages = require('./errorMessages.js');
 const errorCodes = require('./errorCodes.js');
 
 const ERROR_CODE_TO_MESSAGE = {
-	[errorCodes.ERR_MISSING_PASSPHRASE]: errorMessages.KEY_PAIR_ERROR,
-	[errorCodes.ERR_OSSL_BAD_DECRYPT]: errorMessages.KEY_PAIR_ERROR,
-	[errorCodes.ERR_INVALID_USERNAME]: errorMessages.KEY_PAIR_ERROR,
+	[errorCodes.ERR_MISSING_PASSPHRASE]: errorMessages.KEY_PAIR_PASSPHRASE_ERROR,
+	[errorCodes.ERR_OSSL_BAD_DECRYPT]: errorMessages.KEY_PAIR_PASSPHRASE_ERROR,
+	[errorCodes.ERR_INVALID_USERNAME]: errorMessages.KEY_PAIR_USERNAME_ERROR,
 };
 
 const getKeyPairConnectionErrorMessageByCode = code => ERROR_CODE_TO_MESSAGE[code];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12309" title="HCK-12309" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12309</a>  [Snowflake][Key-pair auth] Exception (not user-friendly) error is shown for end user when invalid (not existing) user name is specified
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Changed error message in case of invalid username provided