### PR TITLE
HCK-12758: Application crashes when creating DDL for view with missing references

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -566,7 +566,7 @@ module.exports = (baseProvider, options, app) => {
 						name: `${getName(viewData.isCaseSensitive, key.alias || key.name)}`,
 						isActivated: key.isActivated,
 						comment: preSpace(
-							key.definition.description &&
+							key.definition?.description &&
 								`COMMENT ${escapeString(scriptFormat, key.definition.description)}`,
 						),
 					});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12758" title="HCK-12758" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12758</a>  Application crashes when creating DDL for view with missing references
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Fields in a view with missing references might not have a definition.