### PR TITLE
HCK-13264: add alter script for foreign key constraints

### DIFF
--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -62,6 +62,8 @@ module.exports = {
 	alterTableForeignKey:
 		'ALTER TABLE IF EXISTS ${table_name} ADD ${constraint}FOREIGN KEY (${columns}) REFERENCES ${primary_table} (${primary_columns});',
 
+	dropForeignKey: 'ALTER TABLE IF EXISTS ${tableName} DROP CONSTRAINT ${constraintName};',
+
 	createView:
 		'CREATE${orReplace}${secure}${materialized} VIEW${ifNotExist} ${name} (\n' +
 		'\t${column_list}\n' +

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -1231,5 +1231,18 @@ module.exports = (baseProvider, options, app) => {
 
 			return statements.join('');
 		},
+
+		/**
+		 * Drop a foreign key constraint from a table
+		 * @param {string} tableName - Fully qualified table name
+		 * @param {string} constraintName - Name of the foreign key constraint
+		 * @returns {string}
+		 */
+		dropForeignKey(tableName, constraintName) {
+			return assignTemplates(templates.dropForeignKey, {
+				tableName,
+				constraintName,
+			});
+		},
 	};
 };

--- a/forward_engineering/helpers/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/helpers/alterScriptFromDeltaHelper.js
@@ -14,6 +14,12 @@ const {
 } = require('./alterScriptHelpers/alterEntityHelper');
 const { getAddViewScript, getDeleteViewScript, getModifyViewScript } = require('./alterScriptHelpers/alterViewHelper');
 const { getAddTagScript, getDeleteTagScript, getModifyTagScript } = require('./alterScriptHelpers/alterTagHelper');
+const {
+	getAddForeignKeyScriptDtos,
+	getDeleteForeignKeyScriptDtos,
+	getModifyForeignKeyScriptDtos,
+} = require('./alterScriptHelpers/alterForeignKeyHelper');
+const { commentIfDeactivated } = require('./commentHelpers/commentDeactivatedHelper');
 
 const getItems = (collection, nameProperty, modify, objectMethod) =>
 	[]
@@ -131,12 +137,59 @@ const getAlterTagsScripts = ({ collection, ddlProvider, app }) => {
 	return { addedTagsScripts, deletedTagsScripts, modifiedTagsScripts };
 };
 
+/**
+ * @returns {{ addedFkScripts: string[], deletedFkScripts: string[], modifiedFkScripts: string[] }}
+ */
+const getAlterForeignKeysScripts = ({ collection, ddlProvider }) => {
+	const addedRelationships = getItems(collection, 'relationships', 'added', 'values').filter(
+		rel => rel.role?.compMod?.created,
+	);
+
+	const deletedRelationships = getItems(collection, 'relationships', 'deleted', 'values').filter(
+		rel => rel.role?.compMod?.deleted,
+	);
+
+	const modifiedRelationships = getItems(collection, 'relationships', 'modified', 'values').filter(
+		rel => rel.role?.compMod?.modified,
+	);
+
+	const addedFkScriptDtos = getAddForeignKeyScriptDtos(ddlProvider)(addedRelationships);
+	const deletedFkScriptDtos = getDeleteForeignKeyScriptDtos(ddlProvider)(deletedRelationships);
+	const modifiedFkScriptDtos = getModifyForeignKeyScriptDtos(ddlProvider)(modifiedRelationships);
+
+	// Convert AlterScriptDto objects to strings, commenting out deactivated scripts
+	const convertDtosToScripts = dtos => {
+		return dtos
+			.flatMap(dto => {
+				if (!dto?.scripts) {
+					return [];
+				}
+				return dto.scripts.map(scriptObj => {
+					const script = scriptObj.script;
+					if (!script) {
+						return null;
+					}
+					// Handle deactivated scripts by commenting them out
+					return commentIfDeactivated(script, { isActivated: dto.isActivated });
+				});
+			})
+			.filter(Boolean);
+	};
+
+	const addedFkScripts = convertDtosToScripts(addedFkScriptDtos);
+	const deletedFkScripts = convertDtosToScripts(deletedFkScriptDtos);
+	const modifiedFkScripts = convertDtosToScripts(modifiedFkScriptDtos);
+
+	return { addedFkScripts, deletedFkScripts, modifiedFkScripts };
+};
+
 const getAlterScript = ({ scriptFormat, collection, ddlProvider, app }) => {
 	const script = {
 		...getAlterCollectionsScripts({ collection, ddlProvider, app, scriptFormat }),
 		...getAlterContainersScripts(collection, ddlProvider, app),
 		...getAlterViewsScripts({ schema: collection, ddlProvider, app }),
 		...getAlterTagsScripts({ collection, ddlProvider, app }),
+		...getAlterForeignKeysScripts({ collection, ddlProvider }),
 	};
 	return [
 		'addedTagsScripts',
@@ -146,6 +199,7 @@ const getAlterScript = ({ scriptFormat, collection, ddlProvider, app }) => {
 		'deletedViewScripts',
 		'deletedCollectionScripts',
 		'deletedColumnScripts',
+		'deletedFkScripts',
 		'addedCollectionScripts',
 		'addedColumnScripts',
 		'modifiedCollectionScripts',
@@ -153,6 +207,8 @@ const getAlterScript = ({ scriptFormat, collection, ddlProvider, app }) => {
 		'modifiedColumnScripts',
 		'addedViewScripts',
 		'modifiedViewScripts',
+		'addedFkScripts',
+		'modifiedFkScripts',
 		'deletedTagsScripts',
 		'deletedContainerScripts',
 	]

--- a/forward_engineering/helpers/alterScriptHelpers/alterForeignKeyHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterForeignKeyHelper.js
@@ -1,0 +1,185 @@
+const _ = require('lodash');
+const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { getName } = require('../general');
+
+/**
+ * Get the relationship name (constraint name)
+ * @param {Object} relationship
+ * @return {string}
+ */
+const getRelationshipName = relationship => {
+	return relationship.role?.code || relationship.role?.name || '';
+};
+
+/**
+ * Create ADD FOREIGN KEY statement using ddlProvider
+ * @param {Object} ddlProvider
+ * @return {(relationship: Object) => {isActivated: boolean, statement: string}}
+ */
+const getAddSingleForeignKeyStatementDto = ddlProvider => relationship => {
+	const compMod = relationship.role?.compMod;
+
+	const relationshipName = compMod?.code?.new || compMod?.name?.new || getRelationshipName(relationship) || '';
+
+	return ddlProvider.createForeignKey(
+		{
+			name: relationshipName,
+			foreignKey: compMod?.child?.collection?.fkFields || [],
+			primaryKey: compMod?.parent?.collection?.fkFields || [],
+			customProperties: compMod?.customProperties?.new,
+			foreignTable: compMod?.child?.collection?.name || '',
+			foreignSchemaName: compMod?.child?.bucket?.name || '',
+			foreignTableIsCaseSensitive: compMod?.child?.collection?.isCaseSensitive,
+			foreignTableActivated: compMod?.child?.collection?.isActivated !== false,
+			primaryTable: compMod?.parent?.collection?.name || '',
+			primarySchemaName: compMod?.parent?.bucket?.name || '',
+			primaryTableIsCaseSensitive: compMod?.parent?.collection?.isCaseSensitive,
+			primaryTableActivated: compMod?.parent?.collection?.isActivated !== false,
+			isActivated: compMod?.isActivated?.new !== false,
+		},
+		null,
+		{
+			schemaName: compMod?.child?.bucket?.name || '',
+			databaseName: compMod?.child?.bucket?.database || '',
+			isCaseSensitive: compMod?.child?.collection?.isCaseSensitive,
+		},
+	);
+};
+
+/**
+ * Check if relationship can be added
+ * @param {Object} relationship
+ * @return {boolean}
+ */
+const canRelationshipBeAdded = relationship => {
+	const compMod = relationship.role?.compMod;
+	if (!compMod) {
+		return false;
+	}
+
+	return [
+		compMod.code?.new || compMod.name?.new || getRelationshipName(relationship),
+		compMod.parent?.bucket,
+		compMod.parent?.collection,
+		compMod.parent?.collection?.fkFields?.length,
+		compMod.child?.bucket,
+		compMod.child?.collection,
+		compMod.child?.collection?.fkFields?.length,
+	].every(Boolean);
+};
+
+/**
+ * Get ADD FOREIGN KEY scripts
+ * @param {Object} ddlProvider
+ * @return {(addedRelationships: Array<Object>) => Array<AlterScriptDto>}
+ */
+const getAddForeignKeyScriptDtos = ddlProvider => addedRelationships => {
+	return addedRelationships
+		.filter(relationship => canRelationshipBeAdded(relationship))
+		.map(relationship => {
+			const scriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
+			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, false);
+		})
+		.filter(Boolean)
+		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+};
+
+/**
+ * Create DROP FOREIGN KEY statement
+ * @param {Object} ddlProvider
+ * @return {(relationship: Object) => {isActivated: boolean, statement: string}}
+ */
+const getDeleteSingleForeignKeyStatementDto = ddlProvider => relationship => {
+	const compMod = relationship.role?.compMod;
+
+	const relationshipName = compMod?.code?.old || compMod?.name?.old || getRelationshipName(relationship);
+	const childIsCaseSensitive = compMod?.child?.collection?.isCaseSensitive;
+
+	// Build the full child table name
+	const childBucketName = getName(childIsCaseSensitive, compMod?.child?.bucket?.name);
+	const childDatabaseName = getName(childIsCaseSensitive, compMod?.child?.bucket?.database);
+	const childTableName = getName(childIsCaseSensitive, compMod?.child?.collection?.name);
+
+	let fullChildTableName = childTableName;
+	if (childBucketName) {
+		fullChildTableName = `${childBucketName}.${fullChildTableName}`;
+	}
+	if (childDatabaseName) {
+		fullChildTableName = `${childDatabaseName}.${fullChildTableName}`;
+	}
+
+	const constraintName = getName(childIsCaseSensitive, relationshipName);
+	const statement = ddlProvider.dropForeignKey(fullChildTableName, constraintName);
+
+	const isChildTableActivated = compMod?.child?.collection?.isActivated !== false;
+	const isRelationshipActivated = compMod?.isActivated?.old !== false;
+
+	return {
+		statement,
+		isActivated: isRelationshipActivated && isChildTableActivated,
+	};
+};
+
+/**
+ * Check if relationship can be deleted
+ * @param {Object} relationship
+ * @return {boolean}
+ */
+const canRelationshipBeDeleted = relationship => {
+	const compMod = relationship.role?.compMod;
+	if (!compMod) {
+		return false;
+	}
+
+	return [
+		compMod.code?.old || compMod.name?.old || getRelationshipName(relationship),
+		compMod.child?.bucket,
+		compMod.child?.collection,
+	].every(Boolean);
+};
+
+/**
+ * Get DROP FOREIGN KEY scripts
+ * @param {Object} ddlProvider
+ * @return {(deletedRelationships: Array<Object>) => Array<AlterScriptDto>}
+ */
+const getDeleteForeignKeyScriptDtos = ddlProvider => deletedRelationships => {
+	return deletedRelationships
+		.filter(relationship => canRelationshipBeDeleted(relationship))
+		.map(relationship => {
+			const scriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider)(relationship);
+			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, true);
+		})
+		.filter(Boolean)
+		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+};
+
+/**
+ * Get MODIFY FOREIGN KEY scripts (drop + recreate)
+ * @param {Object} ddlProvider
+ * @return {(modifiedRelationships: Array<Object>) => Array<AlterScriptDto>}
+ */
+const getModifyForeignKeyScriptDtos = ddlProvider => modifiedRelationships => {
+	return modifiedRelationships
+		.filter(relationship => canRelationshipBeAdded(relationship) && canRelationshipBeDeleted(relationship))
+		.map(relationship => {
+			const deleteScriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider)(relationship);
+			const addScriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
+			const isActivated = addScriptDto.isActivated && deleteScriptDto.isActivated;
+
+			return AlterScriptDto.getDropAndRecreateInstance(
+				deleteScriptDto.statement,
+				addScriptDto.statement,
+				isActivated,
+			);
+		})
+		.filter(Boolean)
+		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+};
+
+module.exports = {
+	getAddForeignKeyScriptDtos,
+	getDeleteForeignKeyScriptDtos,
+	getModifyForeignKeyScriptDtos,
+	getRelationshipName,
+};

--- a/forward_engineering/helpers/general.js
+++ b/forward_engineering/helpers/general.js
@@ -149,7 +149,8 @@ const checkIfForeignKeyActivated = fkData =>
 	checkAllKeysActivated(fkData.foreignKey) &&
 	checkAllKeysActivated(fkData.primaryKey) &&
 	fkData.primaryTableActivated &&
-	fkData.foreignTableActivated;
+	fkData.foreignTableActivated &&
+	fkData.isActivated;
 
 const viewColumnsToString = (keys, isParentActivated) => {
 	const mergeCommentWithName = ({ name, comment }) => (comment ? `${name}${comment}` : name);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13264" title="HCK-13264" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13264</a>  Add support FK constraint as a separate statement.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

In this PR:
- Added support for `DROP` and `CREATE` statements in the alter script.
- Added support for the foreign key script generation option, which allows generating a foreign key `CREATE` statement as a separate statement.