### PR TITLE
HCK-13367: keep delimiter in the last column statement if there are constraints after

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -108,10 +108,10 @@ module.exports = (baseProvider, options, app) => {
 
 	const hasActiveConstraints = ({
 		foreignKeyConstraints = [],
-		primaryKeyConstraints = [],
-		uniqueKeyConstraints = [],
+		compositePrimaryKeys = [],
+		compositeUniqueKeys = [],
 	}) => {
-		return [...foreignKeyConstraints, ...primaryKeyConstraints, ...uniqueKeyConstraints].some(
+		return [...foreignKeyConstraints, ...compositePrimaryKeys, ...compositeUniqueKeys].some(
 			constraint => constraint.isActivated,
 		);
 	};

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -106,6 +106,16 @@ module.exports = (baseProvider, options, app) => {
 		tab,
 	});
 
+	const hasActiveConstraints = ({
+		foreignKeyConstraints = [],
+		primaryKeyConstraints = [],
+		uniqueKeyConstraints = [],
+	}) => {
+		return [...foreignKeyConstraints, ...primaryKeyConstraints, ...uniqueKeyConstraints].some(
+			constraint => constraint.isActivated,
+		);
+	};
+
 	const getOutOfLineConstraints = (
 		isParentActivated,
 		foreignKeyConstraints = [],
@@ -117,7 +127,7 @@ module.exports = (baseProvider, options, app) => {
 				isParentActivated ? commentIfDeactivated(constraint.statement, constraint) : constraint.statement,
 		);
 
-		return !isEmpty(constraints) ? ',\n\t\t' + constraints.join(',\n\t\t') : '';
+		return isEmpty(constraints) ? '' : '\n\t\t' + constraints.join(',\n\t\t');
 	};
 
 	function insertNewlinesAtEdges(input) {
@@ -356,7 +366,6 @@ module.exports = (baseProvider, options, app) => {
 			const copyOptions = tab(getCopyOptions(tableData.copyOptions), ' ');
 			const atOrBefore = tab(getAtOrBefore(tableData.cloneParams), ' ');
 			const columns = tableData.columns.map(column => commentIfDeactivated(column.statement, column));
-			const columnDefinitions = joinActivatedAndDeactivatedStatements({ statements: columns, indent: '\n\t\t' });
 			const tagsStatement = getTagStatement({
 				tags: tableData.tableTags,
 				isCaseSensitive: tableData.isCaseSensitive,
@@ -446,7 +455,11 @@ module.exports = (baseProvider, options, app) => {
 					),
 					orReplace,
 					tableIfNotExists,
-					column_definitions: columnDefinitions,
+					column_definitions: joinActivatedAndDeactivatedStatements({
+						statements: columns,
+						indent: '\n\t\t',
+						keepLastDelimiter: hasActiveConstraints(tableData),
+					}),
 					out_of_line_constraints: getOutOfLineConstraints(
 						isActivated,
 						tableData.foreignKeyConstraints,
@@ -466,7 +479,11 @@ module.exports = (baseProvider, options, app) => {
 					[clusterKeys, stageFileFormat, copyOptions, dataRetentionTime, copyGrants, tagsStatement],
 					comment,
 				),
-				column_definitions: columnDefinitions,
+				column_definitions: joinActivatedAndDeactivatedStatements({
+					statements: columns,
+					indent: '\n\t\t',
+					keepLastDelimiter: hasActiveConstraints(tableData),
+				}),
 				out_of_line_constraints: getOutOfLineConstraints(
 					isActivated,
 					tableData.foreignKeyConstraints,

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -30,18 +30,25 @@ const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement
  * }}
  * @return {string}
  * */
-const joinActivatedAndDeactivatedStatements = ({ statements = [], delimiter = ',', indent = '\n' }) => {
+const joinActivatedAndDeactivatedStatements = ({
+	statements = [],
+	delimiter = ',',
+	indent = '\n',
+	keepLastDelimiter = false,
+}) => {
 	const lastIndexOfActivatedStatement = statements.findLastIndex(statement => !statement.startsWith('//'));
 	const numberOfStatements = statements.length;
 
 	return statements
 		.map((statement, index) => {
-			const currentDelimiter = getDelimiter({
-				index,
-				numberOfStatements,
-				lastIndexOfActivatedStatement,
-				delimiter,
-			});
+			const currentDelimiter = keepLastDelimiter
+				? delimiter
+				: getDelimiter({
+						index,
+						numberOfStatements,
+						lastIndexOfActivatedStatement,
+						delimiter,
+					});
 
 			return statement + currentDelimiter;
 		})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13367" title="HCK-13367" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13367</a>  [Script generation options][Snowflake] Missing last coma before constraint makes SQL invalid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
