### PR TITLE
HCK-16327: add the DataHub FE warning message to the localization.

### DIFF
--- a/localization/en.json
+++ b/localization/en.json
@@ -179,5 +179,6 @@
 	"CUSTOM_SCRIPT_CONTAINER_VAR_NAME": "Schema name",
 	"CUSTOM_SCRIPT_CONTAINER_VAR": "schemaName",
 	"CUSTOM_SCRIPT_ENTITY_VAR_NAME": "Table name",
-	"CUSTOM_SCRIPT_ENTITY_VAR": "tableName"
+	"CUSTOM_SCRIPT_ENTITY_VAR": "tableName",
+	"DATAHUB_FALLBACK_TO_PARENT_CONTAINER_NAME_WARNING": "Database property is empty for schema \"${objectName}\". The schema name will be used as the database name in DataHub."
 }

--- a/localization/en.json
+++ b/localization/en.json
@@ -180,5 +180,5 @@
 	"CUSTOM_SCRIPT_CONTAINER_VAR": "schemaName",
 	"CUSTOM_SCRIPT_ENTITY_VAR_NAME": "Table name",
 	"CUSTOM_SCRIPT_ENTITY_VAR": "tableName",
-	"DATAHUB_FALLBACK_TO_PARENT_CONTAINER_NAME_WARNING": "Database property is empty for schema \"${objectName}\". The schema name will be used as the database name in DataHub."
+	"DATAHUB_WARNING_PARENT_CONTAINER_NAME_NOT_FOUND_IN_CONTAINER": "Database property is empty for schema \"${objectName}\". The schema name will be used as the database name in DataHub."
 }


### PR DESCRIPTION
## Content

When there is no database name on schema level, we need to create the database asset in snowflake with schema name and show the warning to the user. This PR adds the warning message.

<img width="630" height="656" alt="Screenshot From 2026-05-29 12-44-59" src="https://github.com/user-attachments/assets/1d9a4837-b632-4164-8851-6b288cd4ef00" />
